### PR TITLE
Updating library to handle custom event formatter

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ SplunkStreamEvent.prototype.log = function (level, msg, meta, callback) {
                 name: meta.name,
                 stack: meta.stack
             };
-        } else if (meta.length) {
+        } else if (Object.keys(meta).length) {
             payload.message.meta = meta;
         }
     }

--- a/index.js
+++ b/index.js
@@ -75,6 +75,12 @@ var SplunkStreamEvent = function (config) {
         this.defaultMetadata.sourcetype = config.splunk.sourcetype
         delete config.splunk.sourcetype;
     }
+    // If evnetFormatter callback mentioned in the splunk object.
+    this.overrideEventFormatter = null;
+    if (config.splunk.eventFormatter) {
+        this.overrideEventFormatter = config.splunk.eventFormatter
+        delete config.splunk.eventFormatter;
+    }
     // This gets around a problem with setting maxBatchCount
     config.splunk.maxBatchCount = 1;
     this.server = new SplunkLogger(config.splunk);
@@ -139,6 +145,15 @@ SplunkStreamEvent.prototype.log = function (level, msg, meta, callback) {
         self.emit('logged');
         callback(null, true);
     });
+
+    // If custom eventFormatter defined.
+    if (this.overrideEventFormatter) {
+      var parent = this;
+      this.server.eventFormatter = function (message, severity) {
+        var event = parent.overrideEventFormatter(message, severity);
+        return event;
+      }
+    }
 };
 
 // Insert this object into the Winston transports list

--- a/test/winston-splunk-httplogger.js
+++ b/test/winston-splunk-httplogger.js
@@ -73,4 +73,9 @@ describe('createLogger', function () {
         var s = new SplunkStreamEvent({ splunk: { token: 'foo' }});
         assert.strictEqual(1, s.config().maxBatchCount);
     });
+
+    it('should allow an override for the default eventFormatter', function() {
+        var s = new SplunkStreamEvent({ splunk: { eventFormatter: 'foo', token: 'foo' }});
+        assert.strictEqual('foo', s.eventFormatter);
+    });
 });


### PR DESCRIPTION
This PR will help clients to handle event formatter using a custom formatter function. 

As of now SplunkLogger is sending data using _defaultEventFormatter
```
function _defaultEventFormatter(message, severity) {
    var event = {
        message: message,
        severity: severity
    };
    return event;
}
``` 
and there is no possibility in _winston-splunk-httplogger_ to have custom eventFormatter. Now with this PR, client who are using _winston-splunk-httplogger_ can pass-on the custom eventFormatter while they initiating _SplunkStreamEvent_ object.
```
var event = new SplunkStreamEvent({
    splunk: {
      token: token,
      host: host,
      eventFormatter: this.eventFormatter // Custom event formatter.
    },
    level: transport.level || 'info'
});
```
Ref: https://github.com/splunk/splunk-javascript-logging/issues/7#issuecomment-224936883