### PR TITLE
Fix custom event formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,65 @@ A [Winston] transport for logging to [Splunk] with a [HTTP Event Collector].
 
 ## Installation
 
-    npm install --save winston winston-splunk-httplogger
+```sh
+npm install --save winston winston-splunk-httplogger
+```
 
 ## Usage
 
-    var winston = require('winston'),
-        SplunkStreamEvent = require('winston-splunk-httplogger');
+```javascript
+var winston = require('winston'),
+    SplunkStreamEvent = require('winston-splunk-httplogger');
 
-    var splunkSettings = {
-            token: process.env.SPLUNK_TOKEN,
-            host: process.env.SPLUNK_HOST || 'localhost'
-    };
+var splunkSettings = {
+    token: process.env.SPLUNK_TOKEN,
+    host: process.env.SPLUNK_HOST || 'localhost'
+};
 
-    // Now use winston as normal
-    var logger = new winston.Logger({
-        transports: [
-            new winston.transports.Console(),
-            new SplunkStreamEvent({ splunk: splunkSettings })
-        ]
-    });
+// Now use winston as normal
+var logger = new winston.Logger({
+    transports: [
+        new winston.transports.Console(),
+        new SplunkStreamEvent({ splunk: splunkSettings })
+    ]
+});
 
-    logger.info('This is sent to Splunk');
+logger.info('This is sent to Splunk');
+```
+
+## API
+
+### splunkTransport = new SplunkStreamEvent(config);
+
+Create a new instance of `SplunkStreamEvent`. Takes the following configuration:
+
+ * **config:** configuration settings for the `SplunkStreamEvent` instance
+ * **config.splunk:** the `Splunk Logger` settings
+ * **config.splunk.token:** the Splunk HTTP Event Collector token
+ * **[config.level=info]:** logging level to use, will show up as the `severity`
+   field of an event
+ * **[config.splunk.source=winston]:** the source for the events sent to Splunk
+ * **[config.splunk.sourcetype=winston-splunk-logger]:** the sourcetype for the
+   events sent to Splunk
+ * **[config.splunk.host=localhost]:** the Splunk HTTP Event Collector host
+ * **[config.splunk.maxRetries=0]:** how many times to retry the splunk logger
+ * **[config.splunk.port=8088]:** the Splunk HTTP Event Collector port
+ * **[config.splunk.path=/services/collector/event/1.0]:** URL path to use
+ * **[config.splunk.protocol=https]:** the protocol to use
+ * **[config.splunk.url]:** URL string to pass to `url.parse`. This will try to
+   set `host`, `path`, `protocol`, `port`, `url`. Any of these values will be
+  overwritten if the corresponding property is set on `config`
+ * **[config.splunk.eventFormatter]:** formats events, returning an event as a
+   string, `function(message, severity)`
+ * **[config.batchInterval=0]:** automatically flush events after this many
+   milliseconds. When set to a non-positive value, events will be sent one by
+   one. This setting is ignored when non-positive
+ * **[config.maxBatchSize=0]:** automatically flush events after the size of
+   queued events exceeds this many bytes. This setting is ignored when
+   non-positive
+ * **[config.maxBatchCount=1]:** automatically flush events after this many
+   events have been queued. Defaults to flush immediately on sending an
+   event. This setting is ignored when non-positive
 
 ## Configuring Splunk
 

--- a/index.js
+++ b/index.js
@@ -76,15 +76,15 @@ var SplunkStreamEvent = function (config) {
         this.defaultMetadata.sourcetype = config.splunk.sourcetype
         delete config.splunk.sourcetype;
     }
-    // If eventFormatter callback mentioned in the splunk object.
-    this.eventFormatter = null;
-    if (typeof config.splunk.eventFormatter !== "undefined") {
-        this.eventFormatter = config.splunk.eventFormatter
-        delete config.splunk.eventFormatter;
-    }
+
     // This gets around a problem with setting maxBatchCount
     config.splunk.maxBatchCount = 1;
     this.server = new SplunkLogger(config.splunk);
+
+    // Override the default event formatter
+    if (config.splunk.eventFormatter) {
+      this.server.eventFormatter = config.splunk.eventFormatter;
+    }
 };
 util.inherits(SplunkStreamEvent, winston.Transport);
 
@@ -146,15 +146,6 @@ SplunkStreamEvent.prototype.log = function (level, msg, meta, callback) {
         self.emit('logged');
         callback(null, true);
     });
-
-    // If custom eventFormatter defined.
-    if (this.eventFormatter) {
-      var parent = this;
-      this.server.eventFormatter = function (message, severity) {
-        var event = parent.eventFormatter(message, severity);
-        return event;
-      }
-    }
 };
 
 // Insert this object into the Winston transports list

--- a/test/winston-splunk-httplogger.js
+++ b/test/winston-splunk-httplogger.js
@@ -76,6 +76,6 @@ describe('createLogger', function () {
 
     it('should allow an override for the default eventFormatter', function() {
         var s = new SplunkStreamEvent({ splunk: { eventFormatter: 'foo', token: 'foo' }});
-        assert.strictEqual('foo', s.eventFormatter);
+        assert.strictEqual('foo', s.server.eventFormatter);
     });
 });


### PR DESCRIPTION
Since the override for the `splunk-logging` event formatter is being done inside the `log` method and after calling the `send` method, the override is not currently working.

My proposal is to override it in the constructor function if `config.splunk.eventFormatter` is present.