### PR TITLE
Emit errors on 4xx or 5xx status codes

### DIFF
--- a/index.js
+++ b/index.js
@@ -144,10 +144,13 @@ SplunkStreamEvent.prototype.log = function (info, callback) {
     }
   }
 
-  this.server.send(payload, function (err) {
+  this.server.send(payload, function (err, resp) {
     if (err) {
       self.emit('error', err);
+    } else if (resp.statusCode >= 400) {
+      self.emit('error', 'Request failed with status code ' + resp.statusCode);    
     }
+    
     self.emit('logged');
     callback(null, true);
   });


### PR DESCRIPTION
The `err` object is not populated on error status codes, so these errors are currently swallowed. This change emits an error when 4xx or 5xx status codes are returned.